### PR TITLE
feat(api): add Orange entity, repository, service, and controller

### DIFF
--- a/src/main/java/com/epita/orangestoremanagement/OrangeStoreManagementApplication.java
+++ b/src/main/java/com/epita/orangestoremanagement/OrangeStoreManagementApplication.java
@@ -9,5 +9,4 @@ public class OrangeStoreManagementApplication {
     public static void main(String[] args) {
         SpringApplication.run(OrangeStoreManagementApplication.class, args);
     }
-
 }

--- a/src/main/java/com/epita/orangestoremanagement/controller/OrangeController.java
+++ b/src/main/java/com/epita/orangestoremanagement/controller/OrangeController.java
@@ -1,0 +1,27 @@
+package com.epita.orangestoremanagement.controller;
+
+import com.epita.orangestoremanagement.model.Orange;
+import com.epita.orangestoremanagement.service.OrangeService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/oranges")
+public class OrangeController {
+
+    private final OrangeService orangeService;
+
+    @Autowired
+    public OrangeController(OrangeService orangeService) {
+        this.orangeService = orangeService;
+    }
+
+    @GetMapping
+    public List<Orange> getAllOranges() {
+        return orangeService.getAllOranges();
+    }
+}

--- a/src/main/java/com/epita/orangestoremanagement/model/Orange.java
+++ b/src/main/java/com/epita/orangestoremanagement/model/Orange.java
@@ -1,0 +1,62 @@
+package com.epita.orangestoremanagement.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "oranges")
+public class Orange {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+    private int quantity;
+    private double price;
+
+    public Orange() {
+    }
+
+    public Orange(String name, int quantity, double price) {
+        this.name = name;
+        this.quantity = quantity;
+        this.price = price;
+    }
+
+    // Getters and setters
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public int getQuantity() {
+        return quantity;
+    }
+
+    public void setQuantity(int quantity) {
+        this.quantity = quantity;
+    }
+
+    public double getPrice() {
+        return price;
+    }
+
+    public void setPrice(double price) {
+        this.price = price;
+    }
+}

--- a/src/main/java/com/epita/orangestoremanagement/repository/OrangeRepository.java
+++ b/src/main/java/com/epita/orangestoremanagement/repository/OrangeRepository.java
@@ -1,0 +1,9 @@
+package com.epita.orangestoremanagement.repository;
+
+import com.epita.orangestoremanagement.model.Orange;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface OrangeRepository extends JpaRepository<Orange, Long> {
+}

--- a/src/main/java/com/epita/orangestoremanagement/service/OrangeService.java
+++ b/src/main/java/com/epita/orangestoremanagement/service/OrangeService.java
@@ -1,0 +1,23 @@
+package com.epita.orangestoremanagement.service;
+
+import com.epita.orangestoremanagement.model.Orange;
+import com.epita.orangestoremanagement.repository.OrangeRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class OrangeService {
+
+    private final OrangeRepository orangeRepository;
+
+    @Autowired
+    public OrangeService(OrangeRepository orangeRepository) {
+        this.orangeRepository = orangeRepository;
+    }
+
+    public List<Orange> getAllOranges() {
+        return orangeRepository.findAll();
+    }
+}


### PR DESCRIPTION
### Summary
- Added Orange entity with fields: id, name, quantity, price.
- Implemented OrangeRepository using Spring Data JPA.
- Created OrangeService to manage orange data.
- Developed OrangeController exposing GET /oranges endpoint.
- Confirmed main application class for Spring Boot startup.